### PR TITLE
Support for simulation on topologically non-euclidean spaces

### DIFF
--- a/agents/agents.go
+++ b/agents/agents.go
@@ -3,28 +3,183 @@ package agents
 import (
 	"fmt"
 	"math"
+	"time"
 )
 
 var (
-	width  int = 800
-	height int = 400
+	width  float64 = 800
+	height float64 = 400
 )
 
-type trajectory func(t float64) Coords
+type Sum func(scalars ...float64) float64
 
-func straightPath(vX float64, vY float64) trajectory {
-	traj := func(t float64) Coords {
-		x := int(t*vX) % width
-		y := int(t*vY) % height
-		return Coords{
-			X: LPFloat{Value: float64(x)}, Y: LPFloat{Value: float64(y)},
+type Diff func(scalarA, scalarB float64) float64
+
+// MetricSpace1D is a representation of the way distance is calculated in a given coordinate.
+// It contains no state, it is an attribute of the environment in which the simulation takes place.
+type MetricSpace1D struct {
+	Sum    Sum
+	Metric Diff
+}
+
+// Line returns a MetricSpace1D that behaves like the usual real numbers unbounded above and below
+func Line() MetricSpace1D {
+	return MetricSpace1D{
+		Sum: func(scalars ...float64) float64 {
+			sum := 0.0
+			for _, summand := range scalars {
+				sum += summand
+			}
+			return sum
+		},
+		Metric: func(scalarA, scalarB float64) float64 {
+			return math.Abs(scalarA - scalarB)
+		},
+	}
+}
+
+// Circles returns a MetricSpace1D that behaves like a circle with the circumference provided (think of an angle parameter)
+func Circles(circumference float64) MetricSpace1D {
+	line := Line()
+	return MetricSpace1D{
+		Sum: func(scalars ...float64) float64 {
+			return math.Remainder(line.Sum(scalars...), circumference)
+		},
+		Metric: func(scalarA, scalarB float64) float64 {
+			result := line.Metric(scalarA, scalarB)
+			if result > circumference/2 {
+				result = math.Abs(circumference - result)
+			}
+			return result
+		},
+	}
+}
+
+// MetricSpace2D is a cartesian product of two MetricSpace1D
+type MetricSpace2D struct {
+	XCoord, YCoord MetricSpace1D
+}
+
+// GeodesicDiff returns a tuple of geodesic distances between two points (x1, y1) and (x2, y2).
+// This defaults to the shortest straight path between the points. This is useful in toroidal topologies.
+func (m MetricSpace2D) GeodesicDiff(x1, x2, y1, y2 float64) (deltaX, deltaY float64) {
+	deltaX = m.XCoord.Metric(x1, x2)
+	deltaY = m.YCoord.Metric(y1, y2)
+	return deltaX, deltaY
+}
+
+// Metric is the function that defines the distance between two points represented by the Vector pair (v1, v2)
+func (m *MetricSpace2D) Metric(v1, v2 *Vector) float64 {
+	deltaX, deltaY := m.GeodesicDiff(v1.X, v2.X, v1.Y, v2.Y)
+	return math.Sqrt(math.Pow(deltaX, 2) + math.Pow(deltaY, 2))
+}
+
+// NewEuclideanPlane initialises a MetricSpace2D that represents euclidean geometry and non-periodic boundary conditions i.e. an
+// infinite 2D plane
+func NewEuclideanPlane() *MetricSpace2D {
+	line := Line()
+	return &MetricSpace2D{
+		XCoord: line,
+		YCoord: line,
+	}
+}
+
+// NewEuclideanToroid initialises a MetricSpace2D that represents geometry and periodic boundary conditions on both axes i.e. a torus.
+// This corresponds to agents leaving the screen on one boundary reappearing at the opposite boundary.
+func NewEuclideanToroid(w, h float64) *MetricSpace2D {
+	return &MetricSpace2D{
+		XCoord: Circles(w),
+		YCoord: Circles(h),
+	}
+}
+
+// NewVector is a method used to initialise a Vector in the metric space m
+func (m *MetricSpace2D) NewVector() *Vector {
+	return &Vector{metricSpace: m}
+}
+
+// Vector represents a point in a space and can be summed in a way that respects linearity. This is a mutable implementation because
+// I don't want to get a memory out.
+type Vector struct {
+	metricSpace *MetricSpace2D
+	X, Y        float64
+}
+
+// Accumulate is a mutating variadic sum
+func (v *Vector) Accumulate(vectors ...*Vector) *Vector {
+	xScalars, yScalars := make([]float64, len(vectors)), make([]float64, len(vectors))
+	for index, summand := range vectors {
+		xScalars[index], yScalars[index] = summand.X, summand.Y
+	}
+	v.X = v.metricSpace.XCoord.Sum(xScalars...)
+	v.Y = v.metricSpace.YCoord.Sum(yScalars...)
+
+	return v
+}
+
+func (v *Vector) Minus(vector *Vector) Vector {
+	deltaX, deltaY := v.metricSpace.GeodesicDiff(v.X, vector.X, v.Y, vector.Y)
+	return Vector{X: deltaX, Y: deltaY}
+}
+
+type Agent struct {
+	Position, Velocity *Vector
+}
+
+func NewAgent(positions, velocities *MetricSpace2D) *Agent {
+	return &Agent{positions.NewVector(), velocities.NewVector()}
+}
+
+// State represents a static snapshot of the simulation at a given time
+type State struct {
+	CoordinateSystem *MetricSpace2D
+	Agents           []*Agent
+}
+
+func NewState(positions, velocities *MetricSpace2D) *State {
+	agents := make([]*Agent, 100)
+	for index, _ := range agents {
+		agents[index] = NewAgent(positions, velocities)
+	}
+	return &State{Agents: agents, CoordinateSystem: positions}
+}
+
+// Distances calculates an array where the value at distances[i][j] is the distance from State.Agents[i] to State.Agents[j]. This has the property that
+// distances[i][j] == distances[j][i] and distances[i][i] == 0
+func (s State) Distances() (distances [][]float64) {
+	distances = make([][]float64, s.Population())
+	for index, _ := range distances {
+		distances[index] = make([]float64, s.Population())
+	}
+
+	for i := 0; i < len(distances); i++ {
+		for j := 0; j < i; j++ {
+			distances[i][j] = s.CoordinateSystem.Metric(s.Agents[i].Position, s.Agents[j].Position)
+			distances[j][i] = distances[i][j]
 		}
 	}
 
-	return traj
+	return distances
 }
 
-var Line = straightPath(30.0, 45.0)
+// Population returns the number of agents
+func (s State) Population() int {
+	population := len(s.Agents)
+	return population
+}
+
+// Scenario is a complete encapsulation of the simulation. It contains the current time, state, topology and simulation timeStep
+type Scenario struct {
+	Time, DeltaT          time.Duration
+	positions, velocities *MetricSpace2D
+	state                 *State
+}
+
+func InitialiseScenario(timeStep time.Duration) Scenario {
+	toroid, euclideanPlane := NewEuclideanToroid(width, height), NewEuclideanPlane()
+	state := NewState(toroid, euclideanPlane)
+	return Scenario{positions: toroid, velocities: euclideanPlane, state: state, DeltaT: timeStep}
+}
 
 // LPFloat serialises as a number represented to a fixed number
 // decimal places eg. 1.00
@@ -48,13 +203,10 @@ type Frame []Coords
 
 // GetFrameAt Retrieves the frame data at time t (in seconds)
 func GetFrameAt(t float64) Frame {
-	return Frame{
-		Coords{
-			X: LPFloat{Value: 100*math.Cos(2*math.Pi*t) + 200},
-			Y: LPFloat{Value: 100*math.Sin(2*math.Pi*t) + 200},
-		},
-		Line(t),
-		Line(t + 0.5),
-		Line(t - 0.5),
-	}
+	return Frame{}
+}
+
+// GetNextFrame is a generator function for Frame instances
+func (s Scenario) GetNextFrame() (frame Frame) {
+	return Frame{}
 }

--- a/domain/agents/agents.go
+++ b/domain/agents/agents.go
@@ -1,0 +1,101 @@
+package agents
+
+import (
+	"fmt"
+	"time"
+	"tjweldon/archetypal-agents/domain/world"
+)
+
+var (
+	width  float64 = 800
+	height float64 = 400
+)
+
+type Agent struct {
+	Position, Velocity *world.Vector
+}
+
+func NewAgent(positions, velocities *world.MetricSpace2D) *Agent {
+	return &Agent{positions.ZeroVector(), velocities.ZeroVector()}
+}
+
+// State represents a static snapshot of the simulation at a given time
+type State struct {
+	CoordinateSystem *world.MetricSpace2D
+	Agents           []*Agent
+}
+
+func NewState(positions, velocities *world.MetricSpace2D) *State {
+	agents := make([]*Agent, 100)
+	for index, _ := range agents {
+		agents[index] = NewAgent(positions, velocities)
+	}
+	return &State{Agents: agents, CoordinateSystem: positions}
+}
+
+// Distances calculates an array where the value at distances[i][j] is the distance from State.Agents[i] to State.Agents[j]. This has the property that
+// distances[i][j] == distances[j][i] and distances[i][i] == 0
+func (s State) Distances() (distances [][]float64) {
+	distances = make([][]float64, s.Population())
+	for index, _ := range distances {
+		distances[index] = make([]float64, s.Population())
+	}
+
+	for i := 0; i < len(distances); i++ {
+		for j := 0; j < i; j++ {
+			distances[i][j] = s.CoordinateSystem.Metric(s.Agents[i].Position, s.Agents[j].Position)
+			distances[j][i] = distances[i][j]
+		}
+	}
+
+	return distances
+}
+
+// Population returns the number of agents
+func (s State) Population() int {
+	population := len(s.Agents)
+	return population
+}
+
+// Scenario is a complete encapsulation of the simulation. It contains the current time, state, topology and simulation timeStep
+type Scenario struct {
+	Time, DeltaT          time.Duration
+	positions, velocities *world.MetricSpace2D
+	state                 *State
+}
+
+func InitialiseScenario(timeStep time.Duration) Scenario {
+	toroid, euclideanPlane := world.NewEuclideanToroid(width, height), world.NewEuclideanPlane()
+	state := NewState(toroid, euclideanPlane)
+	return Scenario{positions: toroid, velocities: euclideanPlane, state: state, DeltaT: timeStep}
+}
+
+// LPFloat serialises as a number represented to a fixed number
+// decimal places eg. 1.00
+type LPFloat struct {
+	Value  float64 // the actual value
+	Digits int     // the number of digits used in json
+}
+
+// MarshalJSON serialises the LPFloat Type
+func (l LPFloat) MarshalJSON() ([]byte, error) {
+	s := fmt.Sprintf("%.*f", l.Digits, l.Value)
+	return []byte(s), nil
+}
+
+type Coords struct {
+	X LPFloat `json:"x"`
+	Y LPFloat `json:"y"`
+}
+
+type Frame []Coords
+
+// GetFrameAt Retrieves the frame data at time t (in seconds)
+func GetFrameAt(t float64) Frame {
+	return Frame{}
+}
+
+// GetNextFrame is a generator function for Frame instances
+func (s Scenario) GetNextFrame() (frame Frame) {
+	return Frame{}
+}

--- a/domain/agents/agents_test.go
+++ b/domain/agents/agents_test.go
@@ -1,0 +1,1 @@
+package agents

--- a/domain/world/circles_test.go
+++ b/domain/world/circles_test.go
@@ -1,0 +1,63 @@
+package world
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+const MaxDegrees = 10.0
+
+func pathLength(circumference, circuits float64) float64 {
+	return circumference * circuits
+}
+
+func TestDistanceBetweenEndsIsSmall(t *testing.T) {
+	circle := Circles(1.0)
+	oneDegree := 1.0 / MaxDegrees
+	minusOneDegree := (MaxDegrees - 1.0) / MaxDegrees
+	minDelta := 10e-9
+
+	geodesic := circle.Metric(oneDegree, minusOneDegree)
+
+	if math.Abs(geodesic-2*oneDegree) > minDelta {
+		t.Fatalf("The distance between +1 degree and -1 degree was off by %e in %e", geodesic-2*oneDegree, geodesic)
+	}
+}
+
+func TestMaximumDistanceIsHalfCircumference(t *testing.T) {
+	cirumference := math.SqrtE
+	circle := Circles(cirumference)
+
+	dists := func(n int) float64 {
+		return circle.Metric(pathLength(cirumference, float64(n)/MaxDegrees), 0)
+	}
+
+	formattedContext := func(angle, offset int) string {
+		return fmt.Sprintf(
+			"{Angle: %d, Distance: %.4f}",
+			angle-offset%MaxDegrees, dists(angle-offset),
+		)
+	}
+
+	for i := range [MaxDegrees * 2]any{} {
+		if dists(i) > cirumference/2 {
+			t.Fatalf("The distance became greater than half the circumference at %s. Preceding distances: %s, %s",
+				formattedContext(i, 0), formattedContext(i, 1), formattedContext(i, 2),
+			)
+		}
+	}
+}
+
+func BenchmarkCirclesDistanceCalculation(b *testing.B) {
+	cirumference := math.SqrtE
+	circle := Circles(cirumference)
+
+	dists := func(n int) float64 {
+		return circle.Metric(pathLength(cirumference, float64(n)/MaxDegrees), 0)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = dists(i)
+	}
+}

--- a/domain/world/circles_test.go
+++ b/domain/world/circles_test.go
@@ -16,17 +16,16 @@ func TestDistanceBetweenEndsIsSmall(t *testing.T) {
 	circle := Circles(1.0)
 	oneDegree := 1.0 / MaxDegrees
 	minusOneDegree := (MaxDegrees - 1.0) / MaxDegrees
-	minDelta := 10e-9
 
 	geodesic := circle.Metric(oneDegree, minusOneDegree)
 
-	if math.Abs(geodesic-2*oneDegree) > minDelta {
+	if math.Abs(geodesic-2*oneDegree) > MaxPrecision {
 		t.Fatalf("The distance between +1 degree and -1 degree was off by %e in %e", geodesic-2*oneDegree, geodesic)
 	}
 }
 
 func TestMaximumDistanceIsHalfCircumference(t *testing.T) {
-	cirumference := math.SqrtE
+	cirumference := 100.0
 	circle := Circles(cirumference)
 
 	dists := func(n int) float64 {

--- a/domain/world/invert_test.go
+++ b/domain/world/invert_test.go
@@ -1,6 +1,9 @@
 package world
 
-import "testing"
+import (
+	"testing"
+	"tjweldon/archetypal-agents/utils"
+)
 
 func TestLine_Invert(t *testing.T) {
 	space := RealLine()
@@ -23,7 +26,7 @@ func inverseTwiceIsIdentity(t *testing.T, space MetricSpace1D) {
 
 	var a float64
 	for range [100]any{} {
-		a = randFloat(-10, 10)
+		a = utils.RandFloat(-10, 10)
 		assertAdjacent(a, space.Invert(space.Invert(a)))
 	}
 }

--- a/domain/world/invert_test.go
+++ b/domain/world/invert_test.go
@@ -1,0 +1,36 @@
+package world
+
+import "testing"
+
+func TestLine_Invert(t *testing.T) {
+	space := RealLine()
+	zeroIsOwnInverse(t, space)
+	inverseTwiceIsIdentity(t, space)
+}
+
+func TestCircles_Invert(t *testing.T) {
+	spaces := [3]MetricSpace1D{
+		Circles(1), Circles(10), Circles(100),
+	}
+	for _, circle := range spaces {
+		zeroIsOwnInverse(t, circle)
+		inverseTwiceIsIdentity(t, circle)
+	}
+}
+
+func inverseTwiceIsIdentity(t *testing.T, space MetricSpace1D) {
+	assertAdjacent := getAdjacencyAssertion(t, space)
+
+	var a float64
+	for range [100]any{} {
+		a = randFloat(-10, 10)
+		assertAdjacent(a, space.Invert(space.Invert(a)))
+	}
+}
+
+func zeroIsOwnInverse(t *testing.T, space MetricSpace1D) {
+	assertAdjacent := getAdjacencyAssertion(t, space)
+	zero := 0.0
+
+	assertAdjacent(space.Invert(zero), zero)
+}

--- a/domain/world/metric_space_2d_test.go
+++ b/domain/world/metric_space_2d_test.go
@@ -5,16 +5,47 @@ import (
 	"testing"
 )
 
-func TestVector_Accumulate_EuclideanPlane(t *testing.T) {
+func TestVector_Accumulate_IsLinear_EuclideanPlane(t *testing.T) {
 	assert.New(t)
-	// arrange
+	// Arrange: generate terms for a sum of vectors n*X + (10 - n)*Y where X and Y are
+	// basis vectors
 	plane := NewEuclideanPlane()
 	basis := [2]*Vector{plane.NewVector(1, 0), plane.NewVector(0, 1)}
-	maxPrecison := 1.0e-9
+	x := randInt(1, 9)
+	y := 10 - x
+
+	terms := generateTerms(x, basis)
+
+	// Action: Accumulate with the terms generated
+	result := plane.ZeroVector().Accumulate(terms...)
+
+	// assert: That result ⋅ X == n and result ⋅ Y == 10 - n
+	assert.LessOrEqual(t, plane.XCoord.Metric(result.X, float64(x)), MaxPrecision)
+	assert.LessOrEqual(t, plane.YCoord.Metric(result.Y, float64(y)), MaxPrecision)
+}
+
+func TestVector_Accumulate_IsLinear_Toroid(t *testing.T) {
+	assert.New(t)
+
+	// Arrange: generate terms for a sum of vectors n*X + (10 - n)*Y where X and Y are
+	// basis vectors
+	plane := NewEuclideanToroid(5, 2)
+	basis := [2]*Vector{plane.NewVector(1, 0), plane.NewVector(0, 1)}
 
 	x := randInt(1, 9)
 	y := 10 - x
 
+	terms := generateTerms(x, basis)
+
+	// Action: Accumulate with the terms generated
+	result := plane.ZeroVector().Accumulate(terms...)
+
+	// assert: That result ⋅ X == n modulo Width and result ⋅ Y == 10 - n modulo Height
+	assert.LessOrEqual(t, plane.XCoord.Metric(result.X, float64(x)), MaxPrecision)
+	assert.LessOrEqual(t, plane.YCoord.Metric(result.Y, float64(y)), MaxPrecision)
+}
+
+func generateTerms(x int, basis [2]*Vector) []*Vector {
 	terms := make([]*Vector, 10)
 	for i := 1; i <= 10; i++ {
 		if i <= x {
@@ -23,11 +54,5 @@ func TestVector_Accumulate_EuclideanPlane(t *testing.T) {
 			terms[i-1] = basis[1]
 		}
 	}
-
-	// action
-	result := plane.ZeroVector().Accumulate(terms...)
-
-	// assert
-	assert.LessOrEqual(t, result.X-float64(x), maxPrecison)
-	assert.LessOrEqual(t, result.Y-float64(y), maxPrecison)
+	return terms
 }

--- a/domain/world/metric_space_2d_test.go
+++ b/domain/world/metric_space_2d_test.go
@@ -3,6 +3,7 @@ package world
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"tjweldon/archetypal-agents/utils"
 )
 
 func TestVector_Accumulate_IsLinear_EuclideanPlane(t *testing.T) {
@@ -11,7 +12,7 @@ func TestVector_Accumulate_IsLinear_EuclideanPlane(t *testing.T) {
 	// basis vectors
 	plane := NewEuclideanPlane()
 	basis := [2]*Vector{plane.NewVector(1, 0), plane.NewVector(0, 1)}
-	x := randInt(1, 9)
+	x := utils.RandInt(1, 9)
 	y := 10 - x
 
 	terms := generateTerms(x, basis)
@@ -32,7 +33,7 @@ func TestVector_Accumulate_IsLinear_Toroid(t *testing.T) {
 	plane := NewEuclideanToroid(5, 2)
 	basis := [2]*Vector{plane.NewVector(1, 0), plane.NewVector(0, 1)}
 
-	x := randInt(1, 9)
+	x := utils.RandInt(1, 9)
 	y := 10 - x
 
 	terms := generateTerms(x, basis)

--- a/domain/world/metric_space_2d_test.go
+++ b/domain/world/metric_space_2d_test.go
@@ -1,0 +1,33 @@
+package world
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestVector_Accumulate_EuclideanPlane(t *testing.T) {
+	assert.New(t)
+	// arrange
+	plane := NewEuclideanPlane()
+	basis := [2]*Vector{plane.NewVector(1, 0), plane.NewVector(0, 1)}
+	maxPrecison := 1.0e-9
+
+	x := randInt(1, 9)
+	y := 10 - x
+
+	terms := make([]*Vector, 10)
+	for i := 1; i <= 10; i++ {
+		if i <= x {
+			terms[i-1] = basis[0]
+		} else {
+			terms[i-1] = basis[1]
+		}
+	}
+
+	// action
+	result := plane.ZeroVector().Accumulate(terms...)
+
+	// assert
+	assert.LessOrEqual(t, result.X-float64(x), maxPrecison)
+	assert.LessOrEqual(t, result.Y-float64(y), maxPrecison)
+}

--- a/domain/world/metric_test.go
+++ b/domain/world/metric_test.go
@@ -1,0 +1,92 @@
+package world
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+const AcceptibleError = 1.0e-9
+
+func randFloat(a, b float64) float64 {
+	lower := math.Min(a, b)
+	return random.Float64()*math.Abs(a-b) + lower
+}
+
+func randInt(a, b int) int {
+	min, max := a, b
+	if b < a {
+		min, max = b, a
+	}
+	diff := max - min + 1
+	return random.Intn(diff) + min
+}
+
+type checker func(m Metric, t *testing.T) float64
+
+type metricDefinitionChecks struct {
+	Symmetry, Positivity, Minimum, TriangleInequality checker
+}
+
+var metricsMustSatisfy = metricDefinitionChecks{
+	Symmetry: func(m Metric, t *testing.T) float64 {
+		a, b := randFloat(-1.0, 1.0), randFloat(-1.0, 1.0)
+		return m(a, b) - m(b, a)
+	},
+	Positivity: func(m Metric, t *testing.T) float64 {
+		a, b := randFloat(-1.0, 1.0), randFloat(-1.0, 1.0)
+		return m(a, b)
+	},
+	Minimum: func(m Metric, t *testing.T) float64 {
+		a := randFloat(-1.0, 1.0)
+		return m(a, a)
+	},
+	TriangleInequality: func(m Metric, t *testing.T) float64 {
+		f := func() float64 { return randFloat(-1.0, 1.0) }
+		a, b, c := f(), f(), f()
+		a2b, b2c, a2c := m(a, b), m(b, c), m(a, c)
+
+		return a2b + b2c - a2c
+	},
+}
+
+func TestLine(t *testing.T) {
+	assert.New(t)
+	m := Line().Metric
+
+	for i := 0; i < 100; i++ {
+		assert.GreaterOrEqual(t, metricsMustSatisfy.Positivity(m, t), 0.0, "Positivity")
+		assert.Equal(t, 0.0, metricsMustSatisfy.Symmetry(m, t), "Symmetry")
+		assert.Equal(t, 0.0, metricsMustSatisfy.Minimum(m, t), "Minimum")
+		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -AcceptibleError, "TriangleInequality")
+	}
+
+}
+
+func TestCircleSmall(t *testing.T) {
+	assert.New(t)
+	m := Circles(1.0).Metric
+
+	for i := 0; i < 100; i++ {
+		assert.GreaterOrEqual(t, metricsMustSatisfy.Positivity(m, t), 0.0, "Positivity")
+		assert.Equal(t, 0.0, metricsMustSatisfy.Symmetry(m, t), "Symmetry")
+		assert.Equal(t, 0.0, metricsMustSatisfy.Minimum(m, t), "Minimum")
+		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -AcceptibleError, "TriangleInequality")
+	}
+}
+
+func TestCircleBig(t *testing.T) {
+	assert.New(t)
+	m := Circles(100.0).Metric
+
+	for i := 0; i < 100; i++ {
+		assert.GreaterOrEqual(t, metricsMustSatisfy.Positivity(m, t), 0.0, "Positivity")
+		assert.Equal(t, 0.0, metricsMustSatisfy.Symmetry(m, t), "Symmetry")
+		assert.Equal(t, 0.0, metricsMustSatisfy.Minimum(m, t), "Minimum")
+		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -AcceptibleError, "TriangleInequality")
+	}
+}

--- a/domain/world/metric_test.go
+++ b/domain/world/metric_test.go
@@ -10,7 +10,7 @@ import (
 
 var random = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-const AcceptibleError = 1.0e-9
+const MaxPrecision = 1.0e-9
 
 func randFloat(a, b float64) float64 {
 	lower := math.Min(a, b)
@@ -62,7 +62,7 @@ func TestLine(t *testing.T) {
 		assert.GreaterOrEqual(t, metricsMustSatisfy.Positivity(m, t), 0.0, "Positivity")
 		assert.Equal(t, 0.0, metricsMustSatisfy.Symmetry(m, t), "Symmetry")
 		assert.Equal(t, 0.0, metricsMustSatisfy.Minimum(m, t), "Minimum")
-		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -AcceptibleError, "TriangleInequality")
+		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -MaxPrecision, "TriangleInequality")
 	}
 
 }
@@ -75,7 +75,7 @@ func TestCircleSmall(t *testing.T) {
 		assert.GreaterOrEqual(t, metricsMustSatisfy.Positivity(m, t), 0.0, "Positivity")
 		assert.Equal(t, 0.0, metricsMustSatisfy.Symmetry(m, t), "Symmetry")
 		assert.Equal(t, 0.0, metricsMustSatisfy.Minimum(m, t), "Minimum")
-		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -AcceptibleError, "TriangleInequality")
+		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -MaxPrecision, "TriangleInequality")
 	}
 }
 
@@ -87,6 +87,6 @@ func TestCircleBig(t *testing.T) {
 		assert.GreaterOrEqual(t, metricsMustSatisfy.Positivity(m, t), 0.0, "Positivity")
 		assert.Equal(t, 0.0, metricsMustSatisfy.Symmetry(m, t), "Symmetry")
 		assert.Equal(t, 0.0, metricsMustSatisfy.Minimum(m, t), "Minimum")
-		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -AcceptibleError, "TriangleInequality")
+		assert.GreaterOrEqual(t, metricsMustSatisfy.TriangleInequality(m, t), -MaxPrecision, "TriangleInequality")
 	}
 }

--- a/domain/world/metric_test.go
+++ b/domain/world/metric_test.go
@@ -2,29 +2,11 @@ package world
 
 import (
 	"github.com/stretchr/testify/assert"
-	"math"
-	"math/rand"
 	"testing"
-	"time"
+	"tjweldon/archetypal-agents/utils"
 )
 
-var random = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 const MaxPrecision = 1.0e-9
-
-func randFloat(a, b float64) float64 {
-	lower := math.Min(a, b)
-	return random.Float64()*math.Abs(a-b) + lower
-}
-
-func randInt(a, b int) int {
-	min, max := a, b
-	if b < a {
-		min, max = b, a
-	}
-	diff := max - min + 1
-	return random.Intn(diff) + min
-}
 
 type checker func(m Metric, t *testing.T) float64
 
@@ -34,19 +16,19 @@ type metricDefinitionChecks struct {
 
 var metricsMustSatisfy = metricDefinitionChecks{
 	Symmetry: func(m Metric, t *testing.T) float64 {
-		a, b := randFloat(-1.0, 1.0), randFloat(-1.0, 1.0)
+		a, b := utils.RandFloat(-1.0, 1.0), utils.RandFloat(-1.0, 1.0)
 		return m(a, b) - m(b, a)
 	},
 	Positivity: func(m Metric, t *testing.T) float64 {
-		a, b := randFloat(-1.0, 1.0), randFloat(-1.0, 1.0)
+		a, b := utils.RandFloat(-1.0, 1.0), utils.RandFloat(-1.0, 1.0)
 		return m(a, b)
 	},
 	Minimum: func(m Metric, t *testing.T) float64 {
-		a := randFloat(-1.0, 1.0)
+		a := utils.RandFloat(-1.0, 1.0)
 		return m(a, a)
 	},
 	TriangleInequality: func(m Metric, t *testing.T) float64 {
-		f := func() float64 { return randFloat(-1.0, 1.0) }
+		f := func() float64 { return utils.RandFloat(-1.0, 1.0) }
 		a, b, c := f(), f(), f()
 		a2b, b2c, a2c := m(a, b), m(b, c), m(a, c)
 

--- a/domain/world/metric_test.go
+++ b/domain/world/metric_test.go
@@ -56,7 +56,7 @@ var metricsMustSatisfy = metricDefinitionChecks{
 
 func TestLine(t *testing.T) {
 	assert.New(t)
-	m := Line().Metric
+	m := RealLine().Metric
 
 	for i := 0; i < 100; i++ {
 		assert.GreaterOrEqual(t, metricsMustSatisfy.Positivity(m, t), 0.0, "Positivity")

--- a/domain/world/sum_test.go
+++ b/domain/world/sum_test.go
@@ -3,6 +3,7 @@ package world
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"tjweldon/archetypal-agents/utils"
 )
 
 func getAdjacencyAssertion(t *testing.T, space MetricSpace1D) func(coordA, coordB float64) {
@@ -36,7 +37,7 @@ func TestCircles_Sum(t *testing.T) {
 func isCommutative(t *testing.T, space MetricSpace1D) {
 	assertAdjacent := getAdjacencyAssertion(t, space)
 	getSummands := func() (alpha float64, beta float64) {
-		alpha, beta = randFloat(-10, 10), randFloat(-10, 10)
+		alpha, beta = utils.RandFloat(-10, 10), utils.RandFloat(-10, 10)
 		return alpha, beta
 	}
 
@@ -53,7 +54,7 @@ func isAssociative(t *testing.T, space MetricSpace1D) {
 	assertAdjacent := getAdjacencyAssertion(t, space)
 	getSummands := func() (summands []float64) {
 		summands = []float64{
-			randFloat(-10, 10), randFloat(-10, 10), randFloat(-10, 10),
+			utils.RandFloat(-10, 10), utils.RandFloat(-10, 10), utils.RandFloat(-10, 10),
 		}
 		return summands
 	}
@@ -81,7 +82,7 @@ func hasZeroElement(t *testing.T, space MetricSpace1D) {
 	var zero, a float64
 
 	for range [100]any{} {
-		a = randFloat(-10, 10)
+		a = utils.RandFloat(-10, 10)
 
 		assertAdjacent(space.Sum(zero, a), a)
 	}
@@ -93,7 +94,7 @@ func inverseExists(t *testing.T, space MetricSpace1D) {
 	var a float64
 
 	for range [100]any{} {
-		a = randFloat(-10, 10)
+		a = utils.RandFloat(-10, 10)
 
 		assertAdjacent(space.Sum(space.Invert(a), a), 0.0)
 	}

--- a/domain/world/sum_test.go
+++ b/domain/world/sum_test.go
@@ -1,0 +1,100 @@
+package world
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func getAdjacencyAssertion(t *testing.T, space MetricSpace1D) func(coordA, coordB float64) {
+	a := assert.New(t)
+	return func(coordA, coordB float64) {
+		separation := space.Metric(coordA, coordB)
+		a.LessOrEqual(separation, MaxPrecision)
+	}
+}
+
+func TestLine_Sum(t *testing.T) {
+	space := RealLine()
+	isCommutative(t, space)
+	isAssociative(t, space)
+	hasZeroElement(t, space)
+	inverseExists(t, space)
+}
+
+func TestCircles_Sum(t *testing.T) {
+	spaces := [3]MetricSpace1D{
+		Circles(1), Circles(10), Circles(100),
+	}
+	for _, circle := range spaces {
+		isCommutative(t, circle)
+		isAssociative(t, circle)
+		hasZeroElement(t, circle)
+		inverseExists(t, circle)
+	}
+}
+
+func isCommutative(t *testing.T, space MetricSpace1D) {
+	assertAdjacent := getAdjacencyAssertion(t, space)
+	getSummands := func() (alpha float64, beta float64) {
+		alpha, beta = randFloat(-10, 10), randFloat(-10, 10)
+		return alpha, beta
+	}
+
+	var a, b float64
+	for range [100]any{} {
+		a, b = getSummands()
+
+		// Assert Sum(a, b) == Sum(b, a)
+		assertAdjacent(space.Sum(a, b), space.Sum(b, a))
+	}
+}
+
+func isAssociative(t *testing.T, space MetricSpace1D) {
+	assertAdjacent := getAdjacencyAssertion(t, space)
+	getSummands := func() (summands []float64) {
+		summands = []float64{
+			randFloat(-10, 10), randFloat(-10, 10), randFloat(-10, 10),
+		}
+		return summands
+	}
+
+	var s, sums []float64
+	for range [100]any{} {
+		s = getSummands()
+		sums = []float64{
+			space.Sum(s[0], space.Sum(s[1], s[2])), // Right fold
+			space.Sum(space.Sum(s[0], s[1]), s[2]), // Left fold
+			space.Sum(s...),                        // Variadic
+		}
+
+		// Assert Sum(a, Sum(b, c)) == Sum(Sum(a, b), c)
+		assertAdjacent(sums[0], sums[1])
+
+		// Assert Sum(a, Sum(b, c)) == Sum(Sum(a, b), c) === Sum(a, b, c)
+		assertAdjacent(sums[0], sums[2])
+		assertAdjacent(sums[1], sums[2])
+	}
+}
+
+func hasZeroElement(t *testing.T, space MetricSpace1D) {
+	assertAdjacent := getAdjacencyAssertion(t, space)
+	var zero, a float64
+
+	for range [100]any{} {
+		a = randFloat(-10, 10)
+
+		assertAdjacent(space.Sum(zero, a), a)
+	}
+}
+
+func inverseExists(t *testing.T, space MetricSpace1D) {
+	assertAdjacent := getAdjacencyAssertion(t, space)
+
+	var a float64
+
+	for range [100]any{} {
+		a = randFloat(-10, 10)
+
+		assertAdjacent(space.Sum(space.Invert(a), a), 0.0)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,11 @@ module tjweldon/archetypal-agents
 go 1.18
 
 require github.com/gorilla/websocket v1.5.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
+github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 	"tjweldon/archetypal-agents/agents"
 )
 
@@ -77,15 +78,15 @@ func streamFrames(w http.ResponseWriter, r *http.Request) {
 func frameGenerator(frameStream chan []agents.Frame, frameRequest chan int) {
 	defer close(frameStream)
 	frameCount := 0
+	simulation := agents.InitialiseScenario(time.Second / 60)
 	for seqLen := range frameRequest {
 		switch seqLen {
 		case -1:
 			return
 		default:
-			var frames []agents.Frame
-			for i := frameCount; i < frameCount+seqLen; i++ {
-				seconds := float64(i) / 60
-				frames = append(frames, agents.GetFrameAt(seconds))
+			frames := make([]agents.Frame, seqLen)
+			for i := 0; i < frameCount; i++ {
+				frames[i] = simulation.GetNextFrame()
 			}
 			frameStream <- frames
 		}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strconv"
 	"time"
-	"tjweldon/archetypal-agents/agents"
+	"tjweldon/archetypal-agents/domain/agents"
 )
 
 var addr = flag.String("addr", "localhost:8080", "http service address")

--- a/utils/rand_util.go
+++ b/utils/rand_util.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func RandFloat(a, b float64) float64 {
+	lower := math.Min(a, b)
+	return random.Float64()*math.Abs(a-b) + lower
+}
+
+func RandInt(a, b int) int {
+	min, max := a, b
+	if b < a {
+		min, max = b, a
+	}
+	diff := max - min + 1
+	return random.Intn(diff) + min
+}

--- a/worlds/worlds.go
+++ b/worlds/worlds.go
@@ -1,0 +1,1 @@
+package worlds


### PR DESCRIPTION
 - Moves the simulation logic to `domain` subfolder.
 - Adds `world` package to enable modular simulation topologies.
 - Adds `State` and `Scenario` data models to `agents` package to represent a snapshot of the simulation and its entire lifecycle respectively.
 - Stubs `GetNextFrame()` interface and updates the app layer client code to interface with this new interface.
 - Adds unit testing for planar and circular coordinate topologies.